### PR TITLE
Index.yaml file is empty when cornell is stopped by SIGTERM

### DIFF
--- a/cornell/cornell_server.py
+++ b/cornell/cornell_server.py
@@ -8,6 +8,7 @@ from functools import partial
 from http import HTTPStatus
 from os import environ
 from pathlib import Path
+import signal
 
 import click
 import requests
@@ -224,6 +225,7 @@ def start_cornell(*, cassettes_dir, forward_uri, port, record, record_once, fixe
     app.logger.info("Starting Cornell", app_name=app.name, port=port, record=record, record_once=record_once,
                     fixed_path=fixed_path, forward_uri=forward_uri, cassettes_dir=str(cassettes_dir))
     atexit.register(on_cornell_exit, app=app)
+    signal.signal(signal.SIGTERM, lambda: on_cornell_exit(app))
     app.run(port=port, threaded=False)
 
 


### PR DESCRIPTION
I run cornell as a background process in automatic testing to record the context of some test. In that case, the file index.yaml is not dumped properly at the end of the process and is empty. It makes replay not usable without removing the index files.

I fix this behavior using signal.signal handler

fix #10