### PR TITLE
keep the headers on classic requests and remove it on redirection

### DIFF
--- a/cornell/cornell_server.py
+++ b/cornell/cornell_server.py
@@ -63,18 +63,18 @@ def _build_initial_request(path):
     return requests.Request(request.method, url=url, headers=headers, data=request.data, params=request.args)
 
 
-def _process_response_body(response):
+def _process_response_body(response: requests.Response):
     response_body = response.raw.read()
     if app.config.record and xml_in_headers(response):
         response_body = replace_locations_in_xml(response_body)
     return response_body
 
 
-def _processes_headers(resp):
-    if resp.status_code not in (HTTPStatus.TEMPORARY_REDIRECT, HTTPStatus.PERMANENT_REDIRECT):
+def _processes_headers(response: requests.Response):
+    if response.status_code in (HTTPStatus.TEMPORARY_REDIRECT, HTTPStatus.PERMANENT_REDIRECT):
         # https://github.com/psf/requests/issues/3490
         for header in ('Content-Length', 'Content-Type', 'Transfer-Encoding'):
-            resp.headers.pop(header, None)
+            response.headers.pop(header, None)
 
 
 @contextmanager

--- a/tests/test_handling_requests.py
+++ b/tests/test_handling_requests.py
@@ -1,0 +1,30 @@
+import requests
+
+from cornell.cornell_server import _processes_headers
+
+
+def test_process_headers_should_keep_content_type_on_ok_request():
+    response = requests.Response()
+    response.status_code = 200
+    response.headers["Content-Type"] = "application/json"
+
+    _processes_headers(response)
+    assert "Content-Type" in response.headers
+
+
+def test_process_headers_should_remove_content_type_on_temporary_redirection():
+    response = requests.Response()
+    response.status_code = 307
+    response.headers["Content-Type"] = "application/json"
+
+    _processes_headers(response)
+    assert "Content-Type" not in response.headers
+
+
+def test_process_headers_should_remove_content_type_on_permanent_redirection():
+    response = requests.Response()
+    response.status_code = 308
+    response.headers["Content-Type"] = "application/json"
+
+    _processes_headers(response)
+    assert "Content-Type" not in response.headers


### PR DESCRIPTION
The header Content-Type is dropped when it's not a redirection. It seems tobe the opposite behavior of the commented out issue. I suppose on this one it's an error of code.

fix #14 