### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Options:
 ## Demo - Full Example
 
 
-Staring Cornell in record mode:
+Start Cornell in record mode:
 
 ```
 cornell -ff https://api.github.com/ --record -cd cassettes


### PR DESCRIPTION
Note this could go a couple of ways, but this way seemed to match tense.